### PR TITLE
Fixing unit tests.  Admittedly not sure why additional configuration …

### DIFF
--- a/src/main/java/srai/configuration/PersonRepositoryConfiguration.java
+++ b/src/main/java/srai/configuration/PersonRepositoryConfiguration.java
@@ -18,6 +18,7 @@ public class PersonRepositoryConfiguration extends RepositoryRestConfigurerAdapt
 	@Override
 	public void configureRepositoryRestConfiguration(RepositoryRestConfiguration config) {
 		config.exposeIdsFor(Person.class);
+		config.setReturnBodyOnCreate(true);
 	}
 
 	@Override

--- a/src/test/java/srai/integration/PersonAPITests.java
+++ b/src/test/java/srai/integration/PersonAPITests.java
@@ -1,92 +1,111 @@
 package srai.integration;
 
-import static com.jayway.restassured.module.mockmvc.RestAssuredMockMvc.given;
-import static org.hamcrest.Matchers.equalTo;
-
-import javax.servlet.http.HttpServletResponse;
-
+import com.jayway.restassured.RestAssured;
+import com.jayway.restassured.http.ContentType;
+import com.jayway.restassured.module.mockmvc.RestAssuredMockMvc;
+import com.jayway.restassured.module.mockmvc.response.MockMvcResponse;
+import com.jayway.restassured.module.mockmvc.response.ValidatableMockMvcResponse;
 import org.flywaydb.test.annotation.FlywayTest;
 import org.flywaydb.test.junit.FlywayTestExecutionListener;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.IntegrationTest;
 import org.springframework.boot.test.SpringApplicationConfiguration;
 import org.springframework.test.context.TestExecutionListeners;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.test.context.support.DependencyInjectionTestExecutionListener;
 import org.springframework.test.context.web.WebAppConfiguration;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.context.WebApplicationContext;
-
-import com.jayway.restassured.http.ContentType;
-import com.jayway.restassured.module.mockmvc.RestAssuredMockMvc;
-import com.jayway.restassured.module.mockmvc.response.ValidatableMockMvcResponse;
-
 import srai.Application;
+
+import javax.servlet.http.HttpServletResponse;
+
+import static com.jayway.restassured.module.mockmvc.RestAssuredMockMvc.given;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
 
 @RunWith(SpringJUnit4ClassRunner.class)
 @SpringApplicationConfiguration(Application.class)
 @TestExecutionListeners({DependencyInjectionTestExecutionListener.class,
 	FlywayTestExecutionListener.class })
-@IntegrationTest
+@IntegrationTest("server.port:0")
 @WebAppConfiguration
 @FlywayTest(locationsForMigrate = {"db/data"})
+@Transactional
 public class PersonAPITests {
 
 	@Autowired
 	private WebApplicationContext context;
 
+	@Value("${local.server.port}")
+	private int port;
+
 	@Before
 	public void setUp() {
+		RestAssured.port = port;
 		RestAssuredMockMvc.webAppContextSetup(context);
 	}
 
 	@Test
 	public void readPersonRecordFixtureSuccess() {
+		// @formatter:off
 		given().
+			log().all(true).
 		when().
-		get("/people/{person_id}", 1).
+			get("/people/{person_id}", 1).
 		then().
-		contentType(ContentType.JSON).
-		statusCode(HttpServletResponse.SC_OK).
-		body("firstName", equalTo("Stuart"));
+			log().all(true).
+			contentType(ContentType.JSON).
+			statusCode(HttpServletResponse.SC_OK).
+			body("firstName", equalTo("Stuart"));
+		// @formatter:on
 	}
 
 	@Test
 	public void createPersonRecordValidationFailure() {
+		// @formatter:off
 		given().
-		contentType(ContentType.JSON).
-		body("{ \"firstName\" : \"Frodo\",  \"lastName\" : \"\" }").
+			contentType(ContentType.JSON).
+			body("{ \"firstName\" : \"Frodo\",  \"lastName\" : \"\" }").
 		when().
-		post("/people").
+			post("/people").
 		then().
-		contentType(ContentType.JSON).
-		statusCode(HttpServletResponse.SC_BAD_REQUEST);
+			contentType(ContentType.JSON).
+			statusCode(HttpServletResponse.SC_BAD_REQUEST);
+		// @formatter:on
 	}
 
 	@Test
 	public void createPersonRecordSuccess() {
-		//MockMvcResponse response =
+		MockMvcResponse response =
+		// @formatter:off
+			given().
+				log().all(true).
+				contentType(ContentType.JSON).
+				body("{ \"firstName\" : \"Frodo\",  \"lastName\" : \"Baggins\" }").
+			when().
+				post("/people").
+			then().
+				log().all(true).
+				contentType(ContentType.JSON).
+				statusCode(HttpServletResponse.SC_CREATED).
+				extract().response();
+		// @formatter:on
 
-		//		String personId =
-		given().
-		contentType(ContentType.JSON).
-		body("{ \"firstName\" : \"Frodo\",  \"lastName\" : \"Baggins\" }").
-		when().
-		post("/people").
-		then().
-		contentType(ContentType.JSON).
-		statusCode(HttpServletResponse.SC_CREATED);
-		//				extract().
-		//				path("id");
-		//				response();
-		//		String r = response.prettyPrint();
-		//		String b = response.body().asString();
-		//		String personId = response.path("id");
-		//		givenExistingPerson(personId).
-		//		and().
-		//		body("firstName", equalTo("Stuart"));
+		int personId = response.path("id");
+		assertThat(personId, is(2));
+//				path("id");
+//						response();
+//				String r = response.prettyPrint();
+//				String b = response.body().asString();
+//				givenExistingPerson(personId).
+//				and().
+//				body("firstName", equalTo("Stuart"));
 	}
 
 	private ValidatableMockMvcResponse givenExistingPerson(String person_id) {


### PR DESCRIPTION
…is needed for tests, but not ./gradlew bootRun.

A few additional notes:
- I uncovered the fact that spring-data-rest wasn't returning a response
  body on the create calls by using log().all(true).  This can be used
  at the given() portion of the DSL (to examine the request), as well as
  at the then() portion (to examine the response).
- @IntegrationTest("server.port:0") will spin up tomcat on an open port,
  allowing you to have the app running via `./gradlew bootRun` and also
  run the unit tests.
- When using @IntegrationTest("server.port:0"), the randomly assigned
  open port must be injected via @Value("${local.server.port}"), and
  then given to RestAssured with RestAssured.port = port;
- Added the @Transactional annotation so that Spring will run each @Test
  method in the context of a transaction, and subsequently rollback the
  transaction after the test completes.  This will help avoid state
  bleed between tests.
